### PR TITLE
feat: new wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snapchat-capi-component"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapchat-capi-component"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ This component implements the data collection protocol between [Edgee](https://w
 3. Add the following configuration to your `edgee.toml`:
 
 ```toml
-[[destinations.data_collection]]
-name = "snapchat_capi"
-component = "/var/edgee/components/snapchat_capi.wasm"
-credentials.snapchat_access_token = "YOUR_ACCESS_TOKEN"
-credentials.snapchat_pixel_id = "YOUR_PIXEL_ID"
-credentials.snapchat_test_event_code = "TEST_EVENT_CODE" # Optional
+[[components.data_collection]]
+id = "snapchat_capi"
+file = "/var/edgee/components/snapchat_capi.wasm"
+settings.snapchat_access_token = "YOUR_ACCESS_TOKEN"
+settings.snapchat_pixel_id = "YOUR_PIXEL_ID"
+settings.snapchat_test_event_code = "TEST_EVENT_CODE" # Optional
 ```
 
 ## Event Handling
@@ -64,23 +64,23 @@ edgee.user({
 
 ### Basic Configuration
 ```toml
-[[destinations.data_collection]]
-name = "snapchat_capi"
-component = "/var/edgee/components/snapchat_capi.wasm"
-credentials.snapchat_access_token = "YOUR_ACCESS_TOKEN"
-credentials.snapchat_pixel_id = "YOUR_PIXEL_ID"
-credentials.snapchat_test_event_code = "TEST_EVENT_CODE" # Optional
+[[components.data_collection]]
+id = "snapchat_capi"
+file = "/var/edgee/components/snapchat_capi.wasm"
+settings.snapchat_access_token = "YOUR_ACCESS_TOKEN"
+settings.snapchat_pixel_id = "YOUR_PIXEL_ID"
+settings.snapchat_test_event_code = "TEST_EVENT_CODE" # Optional
 
 # Optional configurations
-config.default_consent = "pending" # Set default consent status
+settings.edgee_default_consent = "pending" # Set default consent status
 ```
 
 ### Event Controls
 Control which events are forwarded to Snapchat CAPI:
 ```toml
-config.page_event_enabled = true   # Enable/disable page view tracking
-config.track_event_enabled = true  # Enable/disable custom event tracking
-config.user_event_enabled = false   # User event is not provided by the snapchat CAPI
+settings.edgee_page_event_enabled = true   # Enable/disable page view tracking
+settings.edgee_track_event_enabled = true  # Enable/disable custom event tracking
+settings.edgee_user_event_enabled = false   # User event is not provided by the snapchat CAPI
 ```
 
 ### Consent Management

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ export!(SnapchatComponent);
 struct SnapchatComponent;
 
 impl Guest for SnapchatComponent {
-    fn page(edgee_event: Event, cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn page(edgee_event: Event, settings: Dict) -> Result<EdgeeRequest, String> {
         if let Data::Page(ref data) = edgee_event.data {
-            let mut snapchat_payload = SnapchatPayload::new(cred_map).map_err(|e| e.to_string())?;
+            let mut snapchat_payload = SnapchatPayload::new(settings).map_err(|e| e.to_string())?;
 
             let mut event =
                 SnapchatEvent::new(&edgee_event, "PAGE_VIEW").map_err(|e| e.to_string())?;
@@ -48,13 +48,13 @@ impl Guest for SnapchatComponent {
         }
     }
 
-    fn track(edgee_event: Event, cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn track(edgee_event: Event, settings: Dict) -> Result<EdgeeRequest, String> {
         if let Data::Track(ref data) = edgee_event.data {
             if data.name.is_empty() {
                 return Err("Track name is not set".to_string());
             }
 
-            let mut snapchat_payload = SnapchatPayload::new(cred_map).map_err(|e| e.to_string())?;
+            let mut snapchat_payload = SnapchatPayload::new(settings).map_err(|e| e.to_string())?;
             let mut event =
                 SnapchatEvent::new(&edgee_event, data.name.as_str()).map_err(|e| e.to_string())?;
 
@@ -72,7 +72,7 @@ impl Guest for SnapchatComponent {
         }
     }
 
-    fn user(_edgee_event: Event, _cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn user(_edgee_event: Event, _settings: Dict) -> Result<EdgeeRequest, String> {
         Err("User event not implemented for this component".to_string())
     }
 }
@@ -98,6 +98,7 @@ fn build_edgee_request(snapchat_payload: SnapchatPayload) -> EdgeeRequest {
         method: HttpMethod::Post,
         url,
         headers,
+        forward_client_headers: true,
         body: serde_json::to_string(&snapchat_payload).unwrap(),
     }
 }

--- a/src/snapchat_payload.rs
+++ b/src/snapchat_payload.rs
@@ -17,8 +17,8 @@ pub(crate) struct SnapchatPayload {
 }
 
 impl SnapchatPayload {
-    pub fn new(cred_map: Dict) -> anyhow::Result<Self> {
-        let cred: HashMap<String, String> = cred_map
+    pub fn new(settings: Dict) -> anyhow::Result<Self> {
+        let cred: HashMap<String, String> = settings
             .iter()
             .map(|(key, value)| (key.to_string(), value.to_string()))
             .collect();

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,4 +1,4 @@
 [protocols]
-url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
-sha256 = "4d412367fff6f826280acbe95f7067e362d9299d76e60994981e7e27c74d1576"
-sha512 = "65021cace5ed07990fdfb563699accb975a31cb22311739ff6189849b969b06b564a0f8f72de154fd086ba474757d3cffaef0175778e4989c467280cf1c86284"
+url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"
+sha256 = "8b5c8ea97c81d1d6cf4f227e75afb8c4dc5c0a411c3a0401fb7e4f7b745e21ba"
+sha512 = "16771cd12095409e7c4857a8f5c0b4ad680959e3c35dcd7999e11131bcce05d3b1a1b829daefceabbd853ae5b7f6453e3e359ddfbdebd6e2a94db6c55780368f"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,1 +1,1 @@
-protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
+protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"

--- a/wit/deps/protocols/consent-mapping.wit
+++ b/wit/deps/protocols/consent-mapping.wit
@@ -1,7 +1,7 @@
 package edgee:protocols;
 
 interface consent-mapping {
-    type config = list<tuple<string,string>>;
+    type dict = list<tuple<string,string>>;
 
     enum consent {
         pending,
@@ -9,5 +9,5 @@ interface consent-mapping {
         denied,
     }
 
-    map: func(cookie: string, config: config) -> option<consent>;
+    map: func(cookie: string, settings: dict) -> option<consent>;
 }

--- a/wit/deps/protocols/data-collection.wit
+++ b/wit/deps/protocols/data-collection.wit
@@ -102,12 +102,13 @@ interface data-collection {
         method: http-method,
         url: string,
         headers: dict,
+        forward-client-headers: bool,
         body: string,
     }
 
     enum http-method { GET, PUT, POST, DELETE }
 
-    page: func(e: event, cred: dict) -> result<edgee-request, string>;
-    track: func(e: event, cred: dict) -> result<edgee-request, string>;
-    user: func(e: event, cred:dict) -> result<edgee-request, string>;
+    page: func(e: event, settings: dict) -> result<edgee-request, string>;
+    track: func(e: event, settings: dict) -> result<edgee-request, string>;
+    user: func(e: event, settings:dict) -> result<edgee-request, string>;
 }


### PR DESCRIPTION
New wit protocol

- `edgee-request` has now a new field `forward-client-headers`
- change `credentials` with `settings`
- Adapt Readme to reflect latest toml changes